### PR TITLE
build using stable api

### DIFF
--- a/.brigade/project.yaml
+++ b/.brigade/project.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-beta
+# yaml-language-server: $schema=https://schemas.brigade.sh/schemas-v2/project.json
+apiVersion: brigade.sh/v2
 kind: Project
 metadata:
   id: brigade-dockerhub-gateway


### PR DESCRIPTION
The dogfood cluster is now running a custom build from the head of the `v2` branch -- which is close to what we will release as rc.1.

This PR updates the project definition file accordingly. Updating this file doesn't really have any bearing on any of our automation, but it does impact our ability to recreate the project from this definition in the future.