### PR TITLE
use ClusterIP as the default service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Edit `~/brigade-dockerhub-gateway-values.yaml`, making the following changes:
 
 * `brigade.apiToken`: Service account token from step 2
 
+* `service.type`: If you plan to enable ingress (advanced), you can leave this
+  as its default -- `ClusterIP`. If you do not plan to enable ingress, you
+  probably will want to change this value to `LoadBalancer`.
+
 * `tokens`: This field should define tokens that can be used by clients to send
   events (webhooks) to this gateway. Note that keys are completely ignored by
   the gateway and only the values (tokens) matter. The keys only serve as
@@ -114,13 +118,15 @@ $ helm install brigade-dockerhub-gateway \
     --version v0.2.0 \
     --create-namespace \
     --namespace brigade-dockerhub-gateway \
-    --values ~/brigade-dockerhub-gateway-values.yaml
+    --values ~/brigade-dockerhub-gateway-values.yaml \
+    --wait \
+    --timeout 300s
 ```
 
 ### 3. (RECOMMENDED) Create a DNS Entry
 
-If you installed the gateway without enabling support for an ingress controller,
-this command should help you find the gateway's public IP address:
+If you overrode defaults and set `service.type` to `LoadBalancer`, use this
+command to find the gateway's public IP address:
 
 ```console
 $ kubectl get svc brigade-dockerhub-gateway \

--- a/charts/brigade-dockerhub-gateway/values.yaml
+++ b/charts/brigade-dockerhub-gateway/values.yaml
@@ -45,9 +45,8 @@ tls:
   # key: base 64 encoded key goes here
 
 ingress:
-  ## Whether to enable ingress. By default, this is disabled and the gateway's
-  ## service is of type LoadBalancer instead. Enabling ingress is advanced
-  ## usage.
+  ## Whether to enable ingress. By default, this is disabled. Enabling ingress
+  ## is advanced usage.
   enabled: false
   ## Optionally use annotations specified by your ingress controller's
   ## documentation to customize the behavior of the ingress resource.
@@ -103,10 +102,15 @@ nodeSelector: {}
 tolerations: []
 
 service:
-  ## If you're going to use an ingress controller, you can change the service
-  ## type to CLusterIP.
-  type: LoadBalancer
-  # nodePort: 31700
+  ## If you're not going to use an ingress controller, you may want to change
+  ## this value to LoadBalancer for production deployments. If running
+  ## locally, you may want to change it to NodePort OR leave it as ClusterIP
+  ## and use `kubectl port-forward` to map a port on the local network
+  ## interface to the service.
+  type: ClusterIP
+  ## Host port the service will be mapped to when service type is either
+  ## NodePort or LoadBalancer. If not specified, Kubernetes chooses.
+  # nodePort:
 
 brigade:
   ## Address of your Brigade 2 API server, including leading protocol (http://


### PR DESCRIPTION
This leads to a smoother install experience because we can use `--wait`.