### PR TITLE
devx: use ctlptl for setting up and tearing down dev clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ publish-chart:
 	'
 
 ################################################################################
-# Targets to facilitate hacking on Brigade Docker Hub Gateway.                 #
+# Targets to facilitate hacking on this gateway                                #
 ################################################################################
 
 .PHONY: hack-kind-up

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,22 @@ publish-chart:
 # Targets to facilitate hacking on Brigade Docker Hub Gateway.                 #
 ################################################################################
 
+.PHONY: hack-kind-up
+hack-kind-up:
+	ctlptl apply -f hack/kind/cluster.yaml
+	HELM_EXPERIMENTAL_OCI=1 helm upgrade brigade \
+		oci://ghcr.io/brigadecore/brigade \
+		--version v2.3.1 \
+		--install \
+		--create-namespace \
+		--namespace brigade \
+		--wait \
+		--timeout 300s
+
+.PHONY: hack-kind-down
+hack-kind-down:
+	ctlptl delete -f hack/kind/cluster.yaml
+
 .PHONY: hack-build
 hack-build:
 	docker build \

--- a/hack/kind/cluster.yaml
+++ b/hack/kind/cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: kind-brigade-dockerhub-gateway-dev-cluster
+product: kind
+registry: brigade-dev-registry


### PR DESCRIPTION
Follow-up to #59 

This adds new make targets for starting and stopping a kind cluster using ctlptl.

`make hack-kind-up` will _also_ pre-install Brigade with no-frills, so if you're just working on the gateway, this gets you moving really fast.

#59 should be merged first.